### PR TITLE
[YP-624] env: secret 값을 설정파일에서 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,6 @@ gradle-app.setting
 /.idea/misc.xml
 /.idea/modules.xml
 /.idea/vcs.xml
+
+## secret
+application-secret.properties

--- a/yp-online/src/main/resources/application-dev.yaml
+++ b/yp-online/src/main/resources/application-dev.yaml
@@ -1,30 +1,33 @@
 spring:
+  config:
+    import: classpath:application-secret.properties
+
   datasource:
-    url: ${JDBC_DATABASE_URL}
-    sql-script-encoding: UTF-8
+    url: ${DEV_DB_URL}
+    username: ${DEV_DB_USER_NAME}
+    password: ${DEV_DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
 
   jpa:
     hibernate:
-      defer-datasource-initialization: false
-      ddl-auto: update
-    properties:
-      hibernate:
-        #        show_sql: true  #여기는 prinln으로 출력이 나오기 때문에 일단 주석
-        format_sql: true
+      ddl-auto: none    # flyway 적용 전까지
+    defer-datasource-initialization: true
 
   sql:
     init:
-      # category 테이블의 초기 데이터를 생성하고자 할 경우 mode 값 always로 변경
-      mode: always
+      mode: never  # PostgreSQL 15 버전 이상 업그레이드 전까지
       encoding: utf-8
 
 encrypt:
-  secret: yourplanet123456
+  secret: ${DEV_ENCRYPT_SECRET}
 
 file:
-  base-url: http://ec2-15-164-160-23.ap-northeast-2.compute.amazonaws.com:8080
+  base-url: ${DEV_BASE_URL}
   profile-path: /app/files/upload/profile/
   profile-url: /files/profile/
   studio-path: /app/files/upload/studio/
   project-reference-file-path: /app/files/upload/project/reference/
   project-reference-file-url: /files/project/reference/
+
+jwt:
+  secret: ${DEV_JWT_SECRET}

--- a/yp-online/src/main/resources/application-local.yaml
+++ b/yp-online/src/main/resources/application-local.yaml
@@ -1,36 +1,27 @@
-#spring:
-#  datasource:
-#    url: jdbc:h2:tcp://localhost/~/yourplanet
-#    username: sa
-#    password: sa
-#    driver-class-name: org.h2.Driver
-#    sql-script-encoding: UTF-8
-
 spring:
   datasource:
-    url: jdbc:postgresql://svc.sel5.cloudtype.app:30847/postgres
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE
     username: root
-    password: 3wh3o2blr6j8vo3
-    driver-class-name: org.postgresql.Driver
+    password:
+    driver-class-name: org.h2.Driver
 
   jpa:
-    defer-datasource-initialization: false
     hibernate:
-#      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
-        hbm2ddl.auto: update
-#        show_sql: true  #여기는 prinln으로 출력이 나오기 때문에 일단 주석
+        show_sql: true
         format_sql: true
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    defer-datasource-initialization: true
 
   sql:
     init:
-      # category 테이블의 초기 데이터를 생성하고자 할 경우 mode 값 always로 변경
       mode: embedded
       encoding: utf-8
 
 encrypt:
-  secret: yourplanet123456
+  secret: ${DEV_ENCRYPT_SECRET}
 
 file:
   base-url: localhost:8080
@@ -39,3 +30,6 @@ file:
   studio-path: /Users/fong/files/upload/studio/
   project-reference-file-path: /Users/fong/files/upload/project/reference/
   project-reference-file-url: /files/project/reference/
+
+jwt:
+  secret: local_yourplanet

--- a/yp-online/src/main/resources/application.yaml
+++ b/yp-online/src/main/resources/application.yaml
@@ -4,9 +4,6 @@ server:
 spring:
   profiles:
     active: local
-  output:
-    ansi:
-      enabled: always
   servlet:
     multipart:
       max-file-size: 20MB
@@ -19,6 +16,5 @@ logging:
 
 jwt:
   header: X-AUTH-TOKEN
-  secret: A6SSQI4+UWC/bruDrTk/EA1cKaT3UvJME/ZMraCF0Fg=
   access-token-validity-time: 1800000 # milliseconds 30 * 60 * 1000
   refresh-token-validity-time: 86400000 # milliseconds 24 * 60 * 60 * 1000

--- a/yp-online/src/main/resources/data.sql
+++ b/yp-online/src/main/resources/data.sql
@@ -1,15 +1,24 @@
-INSERT INTO category (category_code, category_name, create_date) VALUES ('DAILY_LIFE', '일상', now()) ON CONFLICT (category_code) DO NOTHING;
-INSERT INTO category (category_code, category_name, create_date) VALUES ('EXERCISE', '운동', now()) ON CONFLICT (category_code) DO NOTHING;
-INSERT INTO category (category_code, category_name, create_date) VALUES ('FASHION', '패션', now()) ON CONFLICT (category_code) DO NOTHING;
-INSERT INTO category (category_code, category_name, create_date) VALUES ('PARENTING', '육아', now()) ON CONFLICT (category_code) DO NOTHING;
-INSERT INTO category (category_code, category_name, create_date) VALUES ('BEAUTY', '미용', now()) ON CONFLICT (category_code) DO NOTHING;
-INSERT INTO category (category_code, category_name, create_date) VALUES ('ECONOMY', '경제', now()) ON CONFLICT (category_code) DO NOTHING;
-INSERT INTO category (category_code, category_name, create_date) VALUES ('SELF_IMPROVEMENT', '자기개발', now()) ON CONFLICT (category_code) DO NOTHING;
-INSERT INTO category (category_code, category_name, create_date) VALUES ('EMPATHY', '공감', now()) ON CONFLICT (category_code) DO NOTHING;
-INSERT INTO category (category_code, category_name, create_date) VALUES ('INVESTMENT', '재테크', now()) ON CONFLICT (category_code) DO NOTHING;
-INSERT INTO category (category_code, category_name, create_date) VALUES ('HUMOR', '유머', now()) ON CONFLICT (category_code) DO NOTHING;
-INSERT INTO category (category_code, category_name, create_date) VALUES ('TRAVEL', '여행', now()) ON CONFLICT (category_code) DO NOTHING;
-INSERT INTO category (category_code, category_name, create_date) VALUES ('TIPS', '꿀팁', now()) ON CONFLICT (category_code) DO NOTHING;
-INSERT INTO category (category_code, category_name, create_date) VALUES ('ROMANCE', '연애', now()) ON CONFLICT (category_code) DO NOTHING;
-INSERT INTO category (category_code, category_name, create_date) VALUES ('MARRIAGE', '결혼', now()) ON CONFLICT (category_code) DO NOTHING;
-INSERT INTO category (category_code, category_name, create_date) VALUES ('HEALING', '힐링', now()) ON CONFLICT (category_code) DO NOTHING;
+MERGE INTO category AS target
+USING (VALUES
+           ('DAILY_LIFE', '일상', now()),
+           ('EXERCISE', '운동', now()),
+           ('FASHION', '패션', now()),
+           ('PARENTING', '육아', now()),
+           ('BEAUTY', '미용', now()),
+           ('ECONOMY', '경제', now()),
+           ('SELF_IMPROVEMENT', '자기개발', now()),
+           ('EMPATHY', '공감', now()),
+           ('INVESTMENT', '재테크', now()),
+           ('HUMOR', '유머', now()),
+           ('TRAVEL', '여행', now()),
+           ('TIPS', '꿀팁', now()),
+           ('ROMANCE', '연애', now()),
+           ('MARRIAGE', '결혼', now()),
+           ('HEALING', '힐링', now())
+) AS source (category_code, category_name, create_date)
+    ON target.category_code = source.category_code
+    WHEN MATCHED THEN
+UPDATE SET category_name = source.category_name, create_date = source.create_date
+    WHEN NOT MATCHED THEN
+INSERT (category_code, category_name, create_date)
+VALUES (source.category_code, source.category_name, source.create_date);

--- a/yp-online/src/main/resources/logback-spring.xml
+++ b/yp-online/src/main/resources/logback-spring.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter"/>
+    <conversionRule conversionWord="wEx" converterClass="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter"/>
+
     <springProperty name="profile" source="spring.profiles.active" defaultValue="local"/>
 
     <springProfile name="local">
@@ -23,13 +27,15 @@
     </springProfile>
 
     <!-- log pattern -->
-    <property name="LOG_PATTERN" value="%-5level %d{yy-MM-dd HH:mm:ss} [%thread] [%logger{0}-%M:%line] - %msg%n "/>
+    <property name="CONSOLE_LOG_PATTERN" value="${CONSOLE_LOG_PATTERN:-%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>${LOG_PATTERN}</pattern>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
         </encoder>
     </appender>
+
+    <property name="FILE_LOG_PATTERN" value="%-5level %d{yy-MM-dd HH:mm:ss} [%thread] [%logger{0}-%M:%line] - %msg%n "/>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_PATH}/${LOG_FILE_NAME}.log</file>
@@ -38,7 +44,7 @@
             <maxHistory>10</maxHistory>
         </rollingPolicy>
         <encoder>
-            <pattern>${LOG_PATTERN}</pattern>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
## 💁 해결하려는 문제를 적어주세요
- spring boot 설정 파일에서 비밀 값이 포함되어 있어 보안 상의 문제가 발생 가능
- local 환경에서 h2 DB로 실행 시 기존 data.sql의 postgreSQL 문법이 h2와 호환되지 않는 문제
- 콘솔 로그 출력에 색상이 없는 문제

## 🤔 어떤 방식으로 해결했는지 적어주세요
- 비밀 값을 `application-secret.properties` 파일로 분리했습니다.
- `INSERT ~ ON CONFLICT`문을 `MERGE INTO` 문으로 수정했습니다.
  - postgreSQL 15 버전 이상과 H2에서 호환되지만, 현재 DB가 해당 버전보다 낮기 때문에 dev에서 data.sql로 초기 데이터를 초기화하는 설정을 임시로 false로 설정했습니다.
  - AWS RDS로 마이그레이션하며 버전업 할 예정입니다.
- 콘솔 로그 패턴의 형식을 수정하고 색상을 적용하도록 했습니다.
  - 설정파일 수정
    - `application.yml`에 공통 설정을 작성하고, `dev`와 `local`에 각 환경별 설정을 작성했습니다.
    - `spring.output.ansi.enabled: always` 삭제
    - 해당 설정은 기본 detect로 사용중인 콘솔이 컬러 적용 가능하면 색상 적용하고, 불가능하면 텍스트만 출력합니다.
    - always 설정은 컬러 적용이 불가능한 경우 색상 코드도 같이 출력하기 때문에 가독성이 좋지 않을 것 같아 삭제했습니다.

## 🙋 중점적으로 리뷰 했으면 하는 부분이 있다면 적어주세요
일단 개인적인 의견으로 설정 파일을 수정했는데, 기존 방식에서 바뀌면 안되는 설정이나 다른 의견이 있으시다면 가감없이 리뷰 달아주시면 좋겠습니다.

비밀 값 설정 pr merge 후 ci workflow 작업 예정입니다!

## 🧑‍🏫 이해를 위해 필요한 자료가 있다면 첨부해주세요
- PostgreSQL, H2 호환
  https://github.com/h2database/h2database/issues/2007
  https://stackoverflow.com/questions/73476705/how-to-translate-insert-into-on-conflict-from-postgres-to-h2-merge
- PostgreSQL `merge`
  https://www.crunchydata.com/blog/a-look-at-postgres-15-merge-command-with-examples
