### PR TITLE
[YP-603] doc: Swagger 의존성 변경 (Spring fox -> Spring doc)

### DIFF
--- a/yp-online/build.gradle
+++ b/yp-online/build.gradle
@@ -27,8 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-logging'
 
     // Swagger
-    implementation group: 'io.springfox', name: 'springfox-boot-starter', version: '3.0.0'
-    implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '3.0.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'    // spring boot 3.1.x 호환
 
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/instagram/controller/InstagramController.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/instagram/controller/InstagramController.java
@@ -1,5 +1,6 @@
 package kr.co.yourplanet.online.business.instagram.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.yourplanet.core.enums.StatusCode;
 import kr.co.yourplanet.online.business.instagram.dto.InstagramMediasForm;
 import kr.co.yourplanet.online.business.instagram.service.InstagramService;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Instagram", description = "인스타그램 API")
 @RestController
 @RequiredArgsConstructor
 public class InstagramController {

--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/project/controller/ProjectController.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/project/controller/ProjectController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.co.yourplanet.core.enums.StatusCode;
 import kr.co.yourplanet.online.business.project.dto.request.ProjectAcceptForm;
@@ -30,6 +31,7 @@ import kr.co.yourplanet.online.common.ResponseForm;
 import kr.co.yourplanet.online.jwt.JwtPrincipal;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "Project", description = "프로젝트 API")
 @RestController
 @RequiredArgsConstructor
 public class ProjectController {

--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/studio/controller/CreatorController.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/studio/controller/CreatorController.java
@@ -1,5 +1,6 @@
 package kr.co.yourplanet.online.business.studio.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.yourplanet.core.enums.StatusCode;
 import kr.co.yourplanet.online.business.studio.dto.CreatorBasicInfo;
 import kr.co.yourplanet.online.business.studio.dto.CreatorDetailInfo;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "Creator", description = "작가 API")
 @RestController
 @RequiredArgsConstructor
 public class CreatorController {

--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/studio/controller/StudioController.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/studio/controller/StudioController.java
@@ -1,5 +1,6 @@
 package kr.co.yourplanet.online.business.studio.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.yourplanet.core.enums.StatusCode;
 import kr.co.yourplanet.online.business.studio.dto.PriceInfo;
 import kr.co.yourplanet.online.business.studio.dto.ProfileInfo;
@@ -16,6 +17,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import jakarta.validation.Valid;
 
+@Tag(name = "Studio", description = "스튜디오 API")
 @RestController
 @RequiredArgsConstructor
 public class StudioController {

--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/user/controller/AuthController.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/user/controller/AuthController.java
@@ -1,5 +1,6 @@
 package kr.co.yourplanet.online.business.user.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.yourplanet.core.enums.StatusCode;
 import kr.co.yourplanet.online.business.user.dto.*;
 import kr.co.yourplanet.online.business.user.service.MemberService;
@@ -17,6 +18,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 
+@Tag(name = "Auth", description = "인증 API")
 @RestController
 @RequiredArgsConstructor
 public class AuthController {

--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/user/controller/MemberController.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/user/controller/MemberController.java
@@ -1,5 +1,6 @@
 package kr.co.yourplanet.online.business.user.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.yourplanet.core.enums.StatusCode;
 import kr.co.yourplanet.online.business.user.dto.MemberDetail;
 import kr.co.yourplanet.online.business.user.service.MemberService;
@@ -11,6 +12,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Member", description = "멤버 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor

--- a/yp-online/src/main/java/kr/co/yourplanet/online/config/SwaggerConfig.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/config/SwaggerConfig.java
@@ -1,25 +1,45 @@
 package kr.co.yourplanet.online.config;
 
-import kr.co.yourplanet.online.jwt.JwtPrincipal;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
 
 @Configuration
-@EnableWebMvc
-public class SwaggerConfig implements WebMvcConfigurer {
+public class SwaggerConfig {
+
     @Bean
-    public Docket api() {
-        return new Docket(DocumentationType.OAS_30)
-                .select()
-                .apis(RequestHandlerSelectors.any())
-                .paths(PathSelectors.any())
-                .build()
-                .ignoredParameterTypes(JwtPrincipal.class);
+    public OpenAPI springDocOpenAPI() {
+        return new OpenAPI()
+                .info(apiInfo())
+                .externalDocs(new ExternalDocumentation()
+                        .description("YourPlanet Backend Github")
+                        .url("https://github.com/Your-Planet/back-end"))
+                .addServersItem(new Server().url("/").description("host"))
+                .components(new Components()
+                        .addSecuritySchemes("xAuthToken", bearerAuthScheme()))
+                .addSecurityItem(new SecurityRequirement().addList("xAuthToken"));
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Your Planet API")
+                .description("Your Planet API 명세서입니다.")
+                .version("v1.0.0");
+    }
+
+    private SecurityScheme bearerAuthScheme() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-AUTH-TOKEN")
+                .bearerFormat("JWT")
+                .description("`Bearer ` 접두사 필수");
     }
 }

--- a/yp-online/src/main/resources/application-local.yaml
+++ b/yp-online/src/main/resources/application-local.yaml
@@ -21,7 +21,7 @@ spring:
       encoding: utf-8
 
 encrypt:
-  secret: ${DEV_ENCRYPT_SECRET}
+  secret: FKKTQWMSMillz3Jr4pdFUQ==
 
 file:
   base-url: localhost:8080
@@ -32,4 +32,4 @@ file:
   project-reference-file-url: /files/project/reference/
 
 jwt:
-  secret: local_yourplanet
+  secret: Qb+NiKnqgiFnZnKc7uziuwFX/cq0yzFrJvrpio0JofQ=

--- a/yp-online/src/main/resources/application.yaml
+++ b/yp-online/src/main/resources/application.yaml
@@ -18,3 +18,9 @@ jwt:
   header: X-AUTH-TOKEN
   access-token-validity-time: 1800000 # milliseconds 30 * 60 * 1000
   refresh-token-validity-time: 86400000 # milliseconds 24 * 60 * 60 * 1000
+
+springdoc:
+  swagger-ui:
+    display-request-duration: true
+    operationsSorter: method
+    tags-sorter: alpha


### PR DESCRIPTION
## 💡 유형
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 문서 수정

## 💁 해결하려는 문제를 적어주세요
- 프로젝트의 스프링 부트 버전을 업하면서 기존의 spring fox 의존성이 spring boot 3.x와 호환이 되지 않아 swagger를 사용할 수 없는 문제가 있었습니다.

## 🤔 어떤 방식으로 해결했는지 적어주세요
- 더이상 지원하지 않는 spring fox 의존성에서 현재 스프링 부트 버전인 3.1.3에 호환되는 spring doc 버전인 v 2.2.0으로 의존성을 변경했습니다.
- swagger config에서 명세서 정보와 인증 헤더를 추가했습니다.
- swagger 명세서 ui 정렬 방법을 설정했습니다.
- 모든 기존 컨트롤러에 tag를 적용했습니다.

## 🙋 중점적으로 리뷰 했으면 하는 부분이 있다면 적어주세요
- 추가하고 싶은 기능이 있다면 코멘트로 남겨주세요.

## 🧑‍🏫 이해를 위해 필요한 자료가 있다면 첨부해주세요
- spring doc 2.8.3 doc (2.2.0은 찾지 못함)
https://springdoc.org/#Introduction
- spring boot, spring doc 호환성 매트릭스
https://springdoc.org/#what-is-the-compatibility-matrix-of-springdoc-openapi-with-spring-boot
- spring doc release notes
https://github.com/springdoc/springdoc-openapi/releases
- OpenAPI Specification v3.1.1
https://spec.openapis.org/oas/v3.1.1.html
- springdoc properties
https://springdoc.org/#springdoc-openapi-core-properties