### PR TITLE
[YP-707] fix : Member 엔티티 구조 변경에 따른 작가검색 쿼리 수정

### DIFF
--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/studio/repository/StudioRepositoryImpl.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/studio/repository/StudioRepositoryImpl.java
@@ -1,7 +1,8 @@
 package kr.co.yourplanet.online.business.studio.repository;
 
-import kr.co.yourplanet.core.entity.studio.Category;
-import kr.co.yourplanet.online.business.studio.dao.StudioBasicDao;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.CollectionUtils;
@@ -10,8 +11,8 @@ import org.springframework.util.StringUtils;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.TypedQuery;
-import java.util.ArrayList;
-import java.util.List;
+import kr.co.yourplanet.core.entity.studio.Category;
+import kr.co.yourplanet.online.business.studio.dao.StudioBasicDao;
 
 @Repository
 public class StudioRepositoryImpl implements StudioRepositoryCustom {
@@ -36,7 +37,7 @@ public class StudioRepositoryImpl implements StudioRepositoryCustom {
             conditions.add("s.description like concat('%', :description, '%')");
         }
         if (StringUtils.hasText(instagramUsername)) {
-            conditions.add("m.instagramUsername like concat('%', :instagramUsername, '%')");
+            conditions.add("m.instagramInfo.instagramUsername like concat('%', :instagramUsername, '%')");
         }
         if (!CollectionUtils.isEmpty(categories)) {
             conditions.add("exists (select 1 from ProfileCategoryMap scm2 where scm.profile = scm2.profile and scm2.category in :categories)");
@@ -80,7 +81,7 @@ public class StudioRepositoryImpl implements StudioRepositoryCustom {
         List<Long> profileIds = studioQuery.getResultList();
 
         // 2.1 스튜디오 기본 정보 조회
-        String studioBasicQuery = "select new kr.co.yourplanet.online.business.studio.dao.StudioBasicDao(m.id, s.toonName, s.description, s.profileImageUrl, m.instagramUsername, scm.category.categoryCode) " +
+        String studioBasicQuery = "select new kr.co.yourplanet.online.business.studio.dao.StudioBasicDao(m.id, s.toonName, s.description, s.profileImageUrl, m.instagramInfo.instagramUsername, scm.category.categoryCode) " +
                 "from Profile s " +
                 "join ProfileCategoryMap scm on s.id = scm.profile.id " +
                 "join Member m on s.member.id = m.id " +


### PR DESCRIPTION
Jira: YP-707

## 💡 유형
- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정

## 💁 해결하려는 문제를 적어주세요
- 작가검색 API (GET /creator) 조회 오류 수정

- "작가검색 API"은 4개의 테이블을 참조하며, 4개의 테이블을 Join 하기 위해 동적쿼리로 개발하였습니다.
- 동적쿼리 구문중 `select m.instagramUsername ... Member m ...` 멤버 클래스의 내부 변수를 참조하는 부분이 존재했습니다.
- [YP-304] 이슈에서 멤버 클래스 리펙토링이 있었으며, 이 때 클래스 구조가 변경되며 조회쿼리에서 참조 오류 발생했습니다.

## 🤔 어떤 방식으로 해결했는지 적어주세요
- 변경된 구조 적용  
<img width="323" alt="image" src="https://github.com/user-attachments/assets/1160bde2-37b4-4218-ae5f-c432325a0e65" />


## 🙋 중점적으로 리뷰 했으면 하는 부분이 있다면 적어주세요
- 

## 🧑‍🏫 이해를 위해 필요한 자료가 있다면 첨부해주세요
- 


[YP-304]: https://your-planet.atlassian.net/browse/YP-304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ