### PR TITLE
[YP-750] test: 내 정보 조회, 수정, 계약서 관련 api test 작성

### DIFF
--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/project/dto/request/ContractDraftForm.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/project/dto/request/ContractDraftForm.java
@@ -3,7 +3,9 @@ package kr.co.yourplanet.online.business.project.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import kr.co.yourplanet.core.validation.annotation.ValidIdentificationNumber;
+import lombok.Builder;
 
+@Builder
 public record ContractDraftForm(
 
         @Schema(description = "상호 또는 명칭", nullable = true)

--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/project/service/ContractValidationService.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/project/service/ContractValidationService.java
@@ -40,7 +40,7 @@ public class ContractValidationService {
 
     public void validateContractCompleted(ProjectContract contract) {
         if (contract != null && contract.isCompleted()) {
-            throw new BusinessException(StatusCode.CONFLICT, "이미 작성된 계약서가 존재합니다.", false);
+            throw new BusinessException(StatusCode.CONFLICT, "이미 완료된 계약입니다.", false);
         }
     }
 }

--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/user/dto/MemberFullInfo.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/user/dto/MemberFullInfo.java
@@ -7,12 +7,14 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import kr.co.yourplanet.core.enums.BusinessType;
 import kr.co.yourplanet.core.enums.GenderType;
+import kr.co.yourplanet.core.enums.MemberType;
 import kr.co.yourplanet.core.model.FileMetadata;
 import lombok.Builder;
 
 @Builder
 public record MemberFullInfo(
         Long id,
+        MemberType memberType,
         String instagramUsername,
 
         String email,

--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/user/service/MemberQueryService.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/user/service/MemberQueryService.java
@@ -9,6 +9,8 @@ import kr.co.yourplanet.core.entity.member.AgreementInfo;
 import kr.co.yourplanet.core.entity.member.BusinessInfo;
 import kr.co.yourplanet.core.entity.member.Member;
 import kr.co.yourplanet.core.entity.member.SettlementInfo;
+import kr.co.yourplanet.core.enums.BusinessType;
+import kr.co.yourplanet.core.enums.MemberType;
 import kr.co.yourplanet.core.enums.StatusCode;
 import kr.co.yourplanet.online.business.file.service.FileQueryService;
 import kr.co.yourplanet.online.business.user.dto.FindIdForm;
@@ -75,29 +77,31 @@ public class MemberQueryService {
 
         SettlementInfo settlementInfo = member.getSettlementInfo();
         BusinessInfo businessInfo = member.getBusinessInfo();
+
+        boolean isCreator = MemberType.CREATOR.equals(member.getMemberType());
         boolean isSettlementExist = settlementInfo != null;
-        boolean isBusinessExist = member.getBusinessType() != null;
+        boolean isBusiness = BusinessType.BUSINESS.equals(member.getBusinessType());
 
         return MemberFullInfo.builder()
                 .id(member.getId())
-                .instagramUsername(member.getInstagramInfo().getInstagramUsername())
+                .instagramUsername(isCreator ? member.getInstagramInfo().getInstagramUsername() : null)
                 .email(member.getEmail())
                 .businessType(member.getBusinessType())
                 .name(member.getName())
                 .tel(member.getTel())
                 .birthDate(member.getMemberBasicInfo().getBirthDate())
                 .genderType(member.getGenderType())
-                .companyName(isBusinessExist ? businessInfo.getCompanyName() : null)
-                .businessNumber(isBusinessExist ? businessInfo.getBusinessNumber() : null)
-                .representativeName(isBusinessExist ? businessInfo.getRepresentativeName() : null)
-                .businessAddress(isBusinessExist ? businessInfo.getBusinessAddress() : null)
-                .businessAddressDetail(isBusinessExist ? businessInfo.getBusinessAddressDetail() : null)
+                .companyName(isBusiness ? businessInfo.getCompanyName() : null)
+                .businessNumber(isBusiness ? businessInfo.getBusinessNumber() : null)
+                .representativeName(isBusiness ? businessInfo.getRepresentativeName() : null)
+                .businessAddress(isBusiness ? businessInfo.getBusinessAddress() : null)
+                .businessAddressDetail(isBusiness ? businessInfo.getBusinessAddressDetail() : null)
                 .bankName(isSettlementExist ? settlementInfo.getBankName() : null)
                 .accountHolder(isSettlementExist ? settlementInfo.getAccountHolder() : null)
                 .accountNumber(isSettlementExist ? settlementInfo.getAccountNumber() : null)
-                .maskedRrn(isSettlementExist && !isBusinessExist ? MaskingUtil.maskRRN(settlementInfo.getRrn()) : null)
-                .bankAccountCopyFileMetadata(isSettlementExist && isBusinessExist ? fileQueryService.getFileMetaData(settlementInfo.getBankAccountCopyUrl()) : null)
-                .businessLicenseFileMetadata(isSettlementExist && isBusinessExist ? fileQueryService.getFileMetaData(settlementInfo.getBusinessLicenseUrl()) : null)
+                .maskedRrn(isSettlementExist && !isBusiness ? MaskingUtil.maskRRN(settlementInfo.getRrn()) : null)
+                .bankAccountCopyFileMetadata(isSettlementExist && isBusiness ? fileQueryService.getFileMetaData(settlementInfo.getBankAccountCopyUrl()) : null)
+                .businessLicenseFileMetadata(isSettlementExist && isBusiness ? fileQueryService.getFileMetaData(settlementInfo.getBusinessLicenseUrl()) : null)
                 .build();
     }
 }

--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/user/service/MemberQueryService.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/user/service/MemberQueryService.java
@@ -84,6 +84,7 @@ public class MemberQueryService {
 
         return MemberFullInfo.builder()
                 .id(member.getId())
+                .memberType(member.getMemberType())
                 .instagramUsername(isCreator ? member.getInstagramInfo().getInstagramUsername() : null)
                 .email(member.getEmail())
                 .businessType(member.getBusinessType())

--- a/yp-online/src/main/resources/application.yaml
+++ b/yp-online/src/main/resources/application.yaml
@@ -16,8 +16,6 @@ spring:
 logging:
   level:
     root : info
-    org.hibernate.SQL: debug
-    org.hibernate.type: trace # sql 쿼리 input 값 확인하고 싶을 때
 
 jwt:
   header: X-AUTH-TOKEN

--- a/yp-online/src/test/java/kr/co/yourplanet/online/business/project/controller/ProjectControllerTest.java
+++ b/yp-online/src/test/java/kr/co/yourplanet/online/business/project/controller/ProjectControllerTest.java
@@ -1,0 +1,157 @@
+package kr.co.yourplanet.online.business.project.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import kr.co.yourplanet.core.enums.MemberType;
+import kr.co.yourplanet.helper.WithMockJwtPrincipal;
+import kr.co.yourplanet.online.common.HeaderConstant;
+import kr.co.yourplanet.stub.ProjectContractFormBuilder;
+import kr.co.yourplanet.stub.ProjectStub;
+import kr.co.yourplanet.stub.TokenStub;
+import kr.co.yourplanet.template.IntegrationTest;
+
+class ProjectControllerTest extends IntegrationTest {
+
+    @Nested
+    @DisplayName("계약서 조회 API")
+    class GetProjectContract {
+
+        private final String path = "/project/{id}/contract";
+
+        @DisplayName("[성공] 작가의 프로젝트 계약서 조회에 성공한다.")
+        @Test
+        @WithMockJwtPrincipal(id = 1L, memberType = MemberType.CREATOR)
+        void success_creator() throws Exception {
+            long projectId = ProjectStub.getInProgressProjectWithoutContractId();
+
+            mockMvc.perform(get(path, projectId)
+                            .header(HeaderConstant.ACCESS_TOKEN, TokenStub.getMockAccessToken())
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @DisplayName("[성공] 광고주의 프로젝트 계약서 조회에 성공한다.")
+        @Test
+        @WithMockJwtPrincipal(id = 3L, memberType = MemberType.SPONSOR)
+        void success_sponsor() throws Exception {
+            long projectId = ProjectStub.getInProgressProjectWithoutContractId();
+
+            mockMvc.perform(get(path, projectId)
+                            .header(HeaderConstant.ACCESS_TOKEN, TokenStub.getMockAccessToken())
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @DisplayName("[실패] 계약 당사자가 아닌 경우 계약서 조회에 실패한다.")
+        @Test
+        @WithMockJwtPrincipal(id = 2L, memberType = MemberType.CREATOR)
+        void fail_when_not_contract_party() throws Exception {
+            long projectId = ProjectStub.getInProgressProjectWithoutContractId();
+
+            mockMvc.perform(get(path, projectId)
+                            .header(HeaderConstant.ACCESS_TOKEN, TokenStub.getMockAccessToken())
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+
+        @DisplayName("[실패] 수락된 프로젝트가 아닌 경우 계약서 조회에 실패한다.")
+        @Test
+        @WithMockJwtPrincipal(id = 1L, memberType = MemberType.CREATOR)
+        void fail_when_project_not_accepted() throws Exception {
+            long projectId = ProjectStub.getInReviewProjectId();
+
+            mockMvc.perform(get(path, projectId)
+                            .header(HeaderConstant.ACCESS_TOKEN, TokenStub.getMockAccessToken())
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isConflict());
+        }
+    }
+
+    @Nested
+    @DisplayName("계약서 작성 API")
+    class DraftProjectContract {
+
+        private final String path = "/project/{id}/contract";
+
+        @DisplayName("[성공] 프로젝트 계약서 작성에 성공한다.")
+        @Test
+        @WithMockJwtPrincipal(id = 3L, memberType = MemberType.SPONSOR)
+        void success_sponsor() throws Exception {
+            long projectId = ProjectStub.getInProgressProjectWithContractId();
+
+            mockMvc.perform(post(path, projectId)
+                            .header(HeaderConstant.ACCESS_TOKEN, TokenStub.getMockAccessToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(toJson(ProjectContractFormBuilder.businessContractDraftForm())))
+                    .andDo(print())
+                    .andExpect(status().isCreated());
+        }
+
+        @DisplayName("[실패] 계약 당사자가 아닌 경우 프로젝트 계약서 작성에 실패한다.")
+        @Test
+        @WithMockJwtPrincipal(id = 2L, memberType = MemberType.CREATOR)
+        void fail_when_not_contract_party() throws Exception {
+            long projectId = ProjectStub.getInProgressProjectWithContractId();
+
+            mockMvc.perform(post(path, projectId)
+                            .header(HeaderConstant.ACCESS_TOKEN, TokenStub.getMockAccessToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(toJson(ProjectContractFormBuilder.businessContractDraftForm())))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+
+        @DisplayName("[실패] 수락되지 않은 프로젝트의 경우 프로젝트 계약서 작성에 실패한다.")
+        @Test
+        @WithMockJwtPrincipal(id = 1L, memberType = MemberType.CREATOR)
+        void fail_when_project_not_accepted() throws Exception {
+            long projectId = ProjectStub.getInReviewProjectId();
+
+            mockMvc.perform(post(path, projectId)
+                            .header(HeaderConstant.ACCESS_TOKEN, TokenStub.getMockAccessToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(toJson(ProjectContractFormBuilder.businessContractDraftForm())))
+                    .andDo(print())
+                    .andExpect(status().isConflict());
+        }
+
+        @DisplayName("[실패] 이미 계약서를 작성한 경우 프로젝트 계약서 작성에 실패한다.")
+        @Test
+        @WithMockJwtPrincipal(id = 1L, memberType = MemberType.CREATOR)
+        void fail_when_already_drafted_contract() throws Exception {
+            long projectId = ProjectStub.getInProgressProjectWithContractId();
+
+            mockMvc.perform(post(path, projectId)
+                            .header(HeaderConstant.ACCESS_TOKEN, TokenStub.getMockAccessToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(toJson(ProjectContractFormBuilder.businessContractDraftForm())))
+                    .andDo(print())
+                    .andExpect(status().isConflict());
+        }
+
+        @DisplayName("[실패] 완료된 계약인 경우 프로젝트 계약서 작성에 실패한다.")
+        @Test
+        @WithMockJwtPrincipal(id = 1L, memberType = MemberType.CREATOR)
+        void fail_when_already_contract_finished() throws Exception {
+            long projectId = ProjectStub.getInProgressProjectWithCompletedContractId();
+
+            mockMvc.perform(post(path, projectId)
+                            .header(HeaderConstant.ACCESS_TOKEN, TokenStub.getMockAccessToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(toJson(ProjectContractFormBuilder.businessContractDraftForm())))
+                    .andDo(print())
+                    .andExpect(status().isConflict());
+        }
+    }
+}

--- a/yp-online/src/test/java/kr/co/yourplanet/online/business/user/controller/MemberControllerTest.java
+++ b/yp-online/src/test/java/kr/co/yourplanet/online/business/user/controller/MemberControllerTest.java
@@ -19,7 +19,75 @@ import kr.co.yourplanet.template.IntegrationTest;
 class MemberControllerTest extends IntegrationTest {
 
     @Nested
-    @DisplayName("멤버 정보 수정 API 테스트")
+    @DisplayName("내 정보 조회 API")
+    class GetMyMemberInfo {
+
+        private final String path = "/members/me";
+
+        @DisplayName("[성공] 작가 사업자 - 내 정보 조회에 성공한다.")
+        @Test
+        @WithMockJwtPrincipal(id = 1L, memberType = MemberType.CREATOR)
+        void success_creator_business() throws Exception {
+            mockMvc.perform(get(path)
+                            .header(HeaderConstant.ACCESS_TOKEN, TokenStub.getMockAccessToken())
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.birthDate").isNotEmpty())
+                    .andExpect(jsonPath("$.data.genderType").isNotEmpty())
+                    .andExpect(jsonPath("$.data.companyName").isNotEmpty())
+                    .andExpect(jsonPath("$.data.businessNumber").isNotEmpty())
+                    .andExpect(jsonPath("$.data.representativeName").isNotEmpty())
+                    .andExpect(jsonPath("$.data.businessAddress").isNotEmpty());
+        }
+
+        @DisplayName("[성공] 작가 개인 - 내 정보 조회에 성공한다.")
+        @Test
+        @WithMockJwtPrincipal(id = 2L, memberType = MemberType.CREATOR)
+        void success_creator_individual() throws Exception {
+            mockMvc.perform(get(path)
+                            .header(HeaderConstant.ACCESS_TOKEN, TokenStub.getMockAccessToken())
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.birthDate").isNotEmpty())
+                    .andExpect(jsonPath("$.data.genderType").isNotEmpty());
+        }
+
+        @DisplayName("[성공] 광고주 사업자 - 내 정보 조회에 성공한다.")
+        @Test
+        @WithMockJwtPrincipal(id = 3L, memberType = MemberType.SPONSOR)
+        void success_sponsor_business() throws Exception {
+            mockMvc.perform(get(path)
+                            .header(HeaderConstant.ACCESS_TOKEN, TokenStub.getMockAccessToken())
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.name").isNotEmpty())
+                    .andExpect(jsonPath("$.data.tel").isNotEmpty())
+                    .andExpect(jsonPath("$.data.companyName").isNotEmpty())
+                    .andExpect(jsonPath("$.data.businessNumber").isNotEmpty())
+                    .andExpect(jsonPath("$.data.representativeName").isNotEmpty())
+                    .andExpect(jsonPath("$.data.businessAddress").isNotEmpty());
+        }
+
+        @DisplayName("[성공] 광고주 개인 - 내 정보 조회에 성공한다.")
+        @Test
+        @WithMockJwtPrincipal(id = 4L, memberType = MemberType.SPONSOR)
+        void success_sponsor_individual() throws Exception {
+            mockMvc.perform(get(path)
+                            .header(HeaderConstant.ACCESS_TOKEN, TokenStub.getMockAccessToken())
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.name").isNotEmpty())
+                    .andExpect(jsonPath("$.data.tel").isNotEmpty())
+                    .andExpect(jsonPath("$.data.birthDate").isNotEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("멤버 정보 수정 API")
     class UpdateMemberInfo {
 
         private final String path = "/members/me";
@@ -27,7 +95,7 @@ class MemberControllerTest extends IntegrationTest {
         @DisplayName("[성공] 작가 사업자 - 멤버 정보 수정에 성공한다.")
         @Test
         @WithMockJwtPrincipal(id = 1L, memberType = MemberType.CREATOR)
-        void success_creator_individual() throws Exception {
+        void success_creator_business() throws Exception {
             mockMvc.perform(patch(path)
                             .header(HeaderConstant.ACCESS_TOKEN, TokenStub.getMockAccessToken())
                             .contentType(MediaType.APPLICATION_JSON)
@@ -39,7 +107,7 @@ class MemberControllerTest extends IntegrationTest {
         @DisplayName("[성공] 작가 개인 - 멤버 정보 수정에 성공한다.")
         @Test
         @WithMockJwtPrincipal(id = 2L, memberType = MemberType.CREATOR)
-        void success_creator_business() throws Exception {
+        void success_creator_individual() throws Exception {
             mockMvc.perform(patch(path)
                             .header(HeaderConstant.ACCESS_TOKEN, TokenStub.getMockAccessToken())
                             .contentType(MediaType.APPLICATION_JSON)

--- a/yp-online/src/test/java/kr/co/yourplanet/online/business/user/controller/MemberControllerTest.java
+++ b/yp-online/src/test/java/kr/co/yourplanet/online/business/user/controller/MemberControllerTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
+import kr.co.yourplanet.core.enums.BusinessType;
 import kr.co.yourplanet.core.enums.MemberType;
 import kr.co.yourplanet.helper.WithMockJwtPrincipal;
 import kr.co.yourplanet.online.common.HeaderConstant;
@@ -33,6 +34,8 @@ class MemberControllerTest extends IntegrationTest {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andDo(print())
                     .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.memberType").value(MemberType.CREATOR.name()))
+                    .andExpect(jsonPath("$.data.businessType").value(BusinessType.BUSINESS.name()))
                     .andExpect(jsonPath("$.data.birthDate").isNotEmpty())
                     .andExpect(jsonPath("$.data.genderType").isNotEmpty())
                     .andExpect(jsonPath("$.data.companyName").isNotEmpty())
@@ -50,6 +53,8 @@ class MemberControllerTest extends IntegrationTest {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andDo(print())
                     .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.memberType").value(MemberType.CREATOR.name()))
+                    .andExpect(jsonPath("$.data.businessType").value(BusinessType.INDIVIDUAL.name()))
                     .andExpect(jsonPath("$.data.birthDate").isNotEmpty())
                     .andExpect(jsonPath("$.data.genderType").isNotEmpty());
         }
@@ -63,6 +68,8 @@ class MemberControllerTest extends IntegrationTest {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andDo(print())
                     .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.memberType").value(MemberType.SPONSOR.name()))
+                    .andExpect(jsonPath("$.data.businessType").value(BusinessType.BUSINESS.name()))
                     .andExpect(jsonPath("$.data.name").isNotEmpty())
                     .andExpect(jsonPath("$.data.tel").isNotEmpty())
                     .andExpect(jsonPath("$.data.companyName").isNotEmpty())
@@ -80,6 +87,8 @@ class MemberControllerTest extends IntegrationTest {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andDo(print())
                     .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.memberType").value(MemberType.SPONSOR.name()))
+                    .andExpect(jsonPath("$.data.businessType").value(BusinessType.INDIVIDUAL.name()))
                     .andExpect(jsonPath("$.data.name").isNotEmpty())
                     .andExpect(jsonPath("$.data.tel").isNotEmpty())
                     .andExpect(jsonPath("$.data.birthDate").isNotEmpty());

--- a/yp-online/src/test/java/kr/co/yourplanet/stub/ProjectContractFormBuilder.java
+++ b/yp-online/src/test/java/kr/co/yourplanet/stub/ProjectContractFormBuilder.java
@@ -1,0 +1,23 @@
+package kr.co.yourplanet.stub;
+
+import kr.co.yourplanet.online.business.project.dto.request.ContractDraftForm;
+
+public class ProjectContractFormBuilder {
+
+    public static ContractDraftForm businessContractDraftForm() {
+        return ContractDraftForm.builder()
+                .companyName("Your Planet")
+                .identificationNumber("123-12-12345")
+                .address("서울특별시 강남구 테헤란로 123")
+                .representativeName("사업자 대표자 이름")
+                .build();
+    }
+
+    public static ContractDraftForm individualContractDraftForm() {
+        return ContractDraftForm.builder()
+                .identificationNumber("123456-1234567")
+                .address("서울특별시 서초구 반포대로 58")
+                .representativeName("개인 대표자 이름")
+                .build();
+    }
+}

--- a/yp-online/src/test/java/kr/co/yourplanet/stub/ProjectStub.java
+++ b/yp-online/src/test/java/kr/co/yourplanet/stub/ProjectStub.java
@@ -1,0 +1,20 @@
+package kr.co.yourplanet.stub;
+
+public class ProjectStub {
+
+    public static long getInProgressProjectWithoutContractId() {
+        return 1L;
+    }
+
+    public static long getInReviewProjectId() {
+        return 2L;
+    }
+
+    public static long getInProgressProjectWithContractId() {
+        return 3L;
+    }
+
+    public static long getInProgressProjectWithCompletedContractId() {
+        return 4L;
+    }
+}

--- a/yp-online/src/test/java/kr/co/yourplanet/template/IntegrationTest.java
+++ b/yp-online/src/test/java/kr/co/yourplanet/template/IntegrationTest.java
@@ -25,14 +25,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @Testcontainers
 public abstract class IntegrationTest {
 
-    @Container
-    @ServiceConnection
-    protected static PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:16")
-            .withReuse(true);
+    // TODO: 싱글톤으로 생성되도록 변경 예정
+    // @Container
+    // @ServiceConnection
+    // protected static final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:16")
+    //         .withReuse(true);
 
     @Container
     @ServiceConnection
-    protected static GenericContainer<?> redisContainer = new GenericContainer<>(DockerImageName.parse("redis:6-alpine"))
+    protected static final GenericContainer<?> redisContainer = new GenericContainer<>(DockerImageName.parse("redis:6-alpine"))
             .withExposedPorts(6379);
 
     @Autowired

--- a/yp-online/src/test/resources/application-test.yaml
+++ b/yp-online/src/test/resources/application-test.yaml
@@ -2,7 +2,7 @@ spring:
   config:
     import: classpath:test-secret.properties
   datasource:
-    url: jdbc:tc:postgresql:15:///test
+    url: jdbc:tc:postgresql:16:///test
 
   jpa:
     hibernate:
@@ -37,8 +37,6 @@ file:
   studio-path: /Users/fong/files/upload/studio/
   project-reference-file-path: /Users/fong/files/upload/project/reference/
   project-reference-file-url: /files/project/reference/
-  prefix-secret-file-url: files/secret/local              # base presigned url이 /로 끝나서 생략
-  member-settlement-file-url: /settlements/members/%s/
 
 jwt:
   secret: Qb+NiKnqgiFnZnKc7uziuwFX/cq0yzFrJvrpio0JofQ=

--- a/yp-online/src/test/resources/db/setup.sql
+++ b/yp-online/src/test/resources/db/setup.sql
@@ -112,3 +112,154 @@ VALUES (4,
 INSERT INTO member_salt (id, member_id, create_date, update_date, salt)
 VALUES (4, 4, '2025-02-24 13:07:45.755085', '2025-02-24 13:07:45.755085',
         'xA3hcx8ZqcFSZT0F5VzD2BLJFdDDxW+1aUxyUK0wFoQ=');
+
+
+-- PROFILE --
+
+-- 작가 ID 1의 프로필
+INSERT INTO profile (id, member_id, description, profile_image_path, profile_image_url, toon_name, create_date,
+                     update_date)
+VALUES (1, 1, '작가 ID 1 프로필', '/app/files/upload/profile/sample-profile.jpg',
+        '/files/profile/sample-profile.jpg', '인스타툰', '2024-11-29 19:44:14', '2024-11-29 19:44:14');
+
+
+-- PRICE --
+
+-- 작가 ID 1의 가격
+INSERT INTO price (id, profile_id, additional_cut_option_type, additional_modification_option_type,
+                   additional_origin_file_option_type, additional_post_duration_extension_type,
+                   additional_refinement_option_type, cut_option_price, cut_option_working_days, cuts, is_latest,
+                   modification_count, modification_option_price, modification_option_working_days,
+                   origin_file_option_price, post_duration_extension_price, post_duration_type, price, refinement_price,
+                   working_days, create_date, update_date)
+VALUES (1, 1, 'PROVIDED', 'PROVIDED', 'UNPROVIDED',
+        'PROVIDED', 'UNPROVIDED', 0, 0, 5, true,
+        1, 10000, 2, 5000, 20000,
+        'MORE_THAN_ONE_YEAR', 300000, 15000, 14,
+        '2024-11-29 19:44:37', '2024-11-29 19:44:42');
+
+
+-- PROJECT --
+
+-- ID 1
+-- [IN_PROGRESS]
+-- 작가 ID 1, 광고주 ID 3
+-- 계약서 존재 x
+INSERT INTO project (id, sponsor_id, creator_id, creator_price_id, project_status,
+                     request_date_time, accept_date_time, reject_date_time, accepted_history_id,
+                     brand_name, campaign_description, reference_urls, reject_reason,
+                     create_date, update_date, negotiate_date_time,
+                     complete_date_time, send_date_time, settlement_date_time,
+                     order_title, order_code)
+VALUES (1, 3, 1, 1, 'IN_PROGRESS',
+        '2025-03-18 10:00:00', '2025-03-18 12:00:00', NULL, 1,
+        '브랜드A', '신제품 홍보 캠페인', 'https://example.com/reference', NULL,
+        '2025-03-18 09:00:00', '2025-03-18 12:10:00', '2025-03-19 15:00:00',
+        '2025-03-30 09:00:00', NULL, NULL,
+        'SNS 마케팅 프로젝트', 'ORD20250318001');
+
+-- ID 2
+-- [IN_REVIEW]
+-- 작가 ID 1, 광고주 ID 3
+INSERT INTO project (id, sponsor_id, creator_id, creator_price_id, project_status,
+                     request_date_time, accept_date_time, reject_date_time, accepted_history_id,
+                     brand_name, campaign_description, reference_urls, reject_reason,
+                     create_date, update_date, negotiate_date_time,
+                     complete_date_time, send_date_time, settlement_date_time,
+                     order_title, order_code)
+VALUES (2, 3, 1, 1, 'IN_REVIEW',
+        '2025-03-18 10:00:00', NULL, NULL, NULL,
+        '브랜드A', '신제품 홍보 캠페인', 'https://example.com/reference', NULL,
+        '2025-03-18 09:00:00', '2025-03-18 12:10:00', '2025-03-19 15:00:00',
+        '2025-03-30 09:00:00', NULL, NULL,
+        '유튜브 광고 캠페인', 'ORD20250318025');
+
+-- ID 3
+-- [IN_PROGRESS]
+-- 작가 ID 1, 광고주 ID 3
+-- 공급자만 계약서 작성 완료
+INSERT INTO project (id, sponsor_id, creator_id, creator_price_id, project_status,
+                     request_date_time, accept_date_time, reject_date_time, accepted_history_id,
+                     brand_name, campaign_description, reference_urls, reject_reason,
+                     create_date, update_date, negotiate_date_time,
+                     complete_date_time, send_date_time, settlement_date_time,
+                     order_title, order_code)
+VALUES (3, 3, 1, 1, 'IN_PROGRESS',
+        '2025-03-18 10:00:00', '2025-03-18 12:00:00', NULL, 1,
+        '스타트업B', '프리미엄 제품 런칭 캠페인', 'https://example.com/product-launch', NULL,
+        '2025-03-18 09:00:00', '2025-03-18 12:10:00', '2025-03-19 15:00:00',
+        '2025-03-30 09:00:00', NULL, NULL,
+        '디지털 광고 프로젝트', 'ORD20250318075');
+
+-- ID 4
+-- [IN_PROGRESS]
+-- 작가 ID 1, 광고주 ID 3
+-- 계약서 작성 완료
+INSERT INTO project (id, sponsor_id, creator_id, creator_price_id, project_status,
+                     request_date_time, accept_date_time, reject_date_time, accepted_history_id,
+                     brand_name, campaign_description, reference_urls, reject_reason,
+                     create_date, update_date, negotiate_date_time,
+                     complete_date_time, send_date_time, settlement_date_time,
+                     order_title, order_code)
+VALUES (4, 3, 1, 1, 'IN_PROGRESS',
+        '2025-03-18 10:00:00', '2025-03-18 12:00:00', NULL, 1,
+        '스타트업B', '프리미엄 제품 런칭 캠페인', 'https://example.com/product-launch', NULL,
+        '2025-03-18 09:00:00', '2025-03-18 12:10:00', '2025-03-19 15:00:00',
+        '2025-03-30 09:00:00', NULL, NULL,
+        '디지털 광고 프로젝트', 'ORD20250318982');
+
+
+-- PROJECT HISTORY --
+
+-- 프로젝트 ID 1의 히스토리 (계약서 x)
+INSERT INTO project_history (id, project_id, seq, project_status, request_member_id, additional_modification_count,
+                             additional_panel_count, additional_panel_negotiable, due_date, offer_price,
+                             origin_file_demand_type, post_duration_extension_months, refinement_demand_type,
+                             message, post_start_dates, create_date, update_date)
+VALUES (1, 1, 1, 'IN_PROGRESS', 3, 1, 2,
+        true, '2025-04-05', 450000, 'DEMANDED', 2,
+        'NOT_DEMANDED', '일정 확정 중',
+        '2025-03-26,2025-03-27', '2025-03-18 14:00:00', '2025-03-18 14:30:00');
+
+-- 프로젝트 ID 3의 히스토리 (계약서 o)
+INSERT INTO project_history (id, project_id, seq, project_status, request_member_id, additional_modification_count,
+                             additional_panel_count, additional_panel_negotiable, due_date, offer_price,
+                             origin_file_demand_type, post_duration_extension_months, refinement_demand_type,
+                             message, post_start_dates, create_date, update_date)
+VALUES (2, 3, 1, 'IN_PROGRESS', 3, 1, 2,
+        true, '2025-04-05', 450000, 'DEMANDED', 2,
+        'NOT_DEMANDED', '일정 확정 중',
+        '2025-03-26,2025-03-27', '2025-03-18 14:00:00', '2025-03-18 14:30:00');
+
+-- 프로젝트 ID 4의 히스토리 (계약서 o)
+INSERT INTO project_history (id, project_id, seq, project_status, request_member_id, additional_modification_count,
+                             additional_panel_count, additional_panel_negotiable, due_date, offer_price,
+                             origin_file_demand_type, post_duration_extension_months, refinement_demand_type,
+                             message, post_start_dates, create_date, update_date)
+VALUES (3, 4, 1, 'IN_PROGRESS', 3, 1, 2,
+        true, '2025-04-05', 450000, 'DEMANDED', 2,
+        'NOT_DEMANDED', '일정 확정 중',
+        '2025-03-26,2025-03-27', '2025-03-18 14:00:00', '2025-03-18 14:30:00');
+
+
+-- CONTRACT --
+
+-- 프로젝트 ID 3의 미완성 계약서
+INSERT INTO project_contract (id, project_id, accept_date_time, complete_date_time, contract_amount,
+                              provider_company_name, provider_registration_number, provider_address,
+                              provider_representative_name, provider_written_date_time)
+VALUES (1, 3, '2025-03-18 12:00:00', '2025-03-20 18:00:00', 500000,
+        '디자인 주식회사', '987-65-43210', '부산광역시 해운대구 센텀로 45',
+        '이영희', '2025-03-18 10:00:00');
+
+-- 프로젝트 ID 4의 완성 계약서
+INSERT INTO project_contract (id, project_id, accept_date_time, complete_date_time, contract_amount,
+                              client_company_name, client_registration_number, client_address,
+                              client_representative_name,
+                              provider_company_name, provider_registration_number, provider_address,
+                              provider_representative_name,
+                              provider_written_date_time, client_written_date_time)
+VALUES (2, 4, '2025-03-18 12:00:00', '2025-03-20 18:00:00', 750000,
+        'ABC 기업', '123-45-67890', '서울특별시 강남구 테헤란로 123', '김철수',
+        '디자인 주식회사', '987-65-43210', '부산광역시 해운대구 센텀로 45', '이영희',
+        '2025-03-17 15:00:00', '2025-03-18 10:00:00');


### PR DESCRIPTION
## 💡 유형
- [x] 버그 수정
- [x] 테스트 추가, 테스트 리팩토링

## 🤔 어떤 방식으로 해결했는지 적어주세요
- 이전 구현한 API의 테스트를 작성했습니다.
- 내 정보 조회 API의 member type에 따라 분기되지 않는 에러를 수정했습니다.
- 내 정보 조회, 수정, 계약서 조회, 작성 API의 테스트를 작성했습니다.
- 결제 관련 API는 추후 요청, 승인을 테스트할 수 있는 방법을 찾아 작성하겠습니다.
- test container가 테스트마다 초기화되어 현재는 임시로 스프링부트에서 postgresql 컨테이너를 생성하도록 수정했습니다.
- 이후 싱글톤으로 사용할 수 있도록 변경할 예정입니다.
