### PR TITLE
[YP-753] feat: 계약서 작성 시 기존 정보 불러오기 기능 구현

### DIFF
--- a/yp-core/src/main/java/kr/co/yourplanet/core/entity/member/Member.java
+++ b/yp-core/src/main/java/kr/co/yourplanet/core/entity/member/Member.java
@@ -83,6 +83,9 @@ public class Member extends BasicColumn {
         return MemberType.SPONSOR.equals(this.getMemberType());
     }
 
+    public boolean hasSettlementInfo() {
+        return this.settlementInfo != null;
+    }
 
     // Simplified Getters
     public String getEmail() {

--- a/yp-core/src/main/java/kr/co/yourplanet/core/entity/project/Contractor.java
+++ b/yp-core/src/main/java/kr/co/yourplanet/core/entity/project/Contractor.java
@@ -19,7 +19,7 @@ public class Contractor {
 
     @Comment("상호 또는 명칭")
     @Column(nullable = true)
-    private String companyName;
+    private String name;
 
     @Comment("사업자 등록번호 혹은 주민번호")
     private String registrationNumber;

--- a/yp-core/src/main/java/kr/co/yourplanet/core/entity/project/ProjectContract.java
+++ b/yp-core/src/main/java/kr/co/yourplanet/core/entity/project/ProjectContract.java
@@ -15,7 +15,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.SequenceGenerator;
-import kr.co.yourplanet.core.entity.studio.Price;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -53,7 +52,7 @@ public class ProjectContract {
     @Comment("디자인 수요자 정보")
     @Embedded
     @AttributeOverrides({
-            @AttributeOverride(name = "companyName", column = @Column(name = "client_company_name")),
+            @AttributeOverride(name = "name", column = @Column(name = "client_company_name")),
             @AttributeOverride(name = "registrationNumber", column = @Column(name = "client_registration_number")),
             @AttributeOverride(name = "address", column = @Column(name = "client_address")),
             @AttributeOverride(name = "representativeName", column = @Column(name = "client_representative_name"))
@@ -63,7 +62,7 @@ public class ProjectContract {
     @Comment("디자인 공급자 정보")
     @Embedded
     @AttributeOverrides({
-            @AttributeOverride(name = "companyName", column = @Column(name = "provider_company_name")),
+            @AttributeOverride(name = "name", column = @Column(name = "provider_company_name")),
             @AttributeOverride(name = "registrationNumber", column = @Column(name = "provider_registration_number")),
             @AttributeOverride(name = "address", column = @Column(name = "provider_address")),
             @AttributeOverride(name = "representativeName", column = @Column(name = "provider_representative_name"))

--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/user/service/MemberQueryService.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/user/service/MemberQueryService.java
@@ -79,7 +79,7 @@ public class MemberQueryService {
         BusinessInfo businessInfo = member.getBusinessInfo();
 
         boolean isCreator = MemberType.CREATOR.equals(member.getMemberType());
-        boolean isSettlementExist = settlementInfo != null;
+        boolean isSettlementExist = member.hasSettlementInfo();
         boolean isBusiness = BusinessType.BUSINESS.equals(member.getBusinessType());
 
         return MemberFullInfo.builder()


### PR DESCRIPTION
## 💡 유형
- [x] 새로운 기능 추가

## 💁 해결하려는 문제를 적어주세요
- 계약서 작성을 위해 조회 시 기존의 사업 정보/정산 정보를 불러오는 기획이 추가되었습니다.

## 🤔 어떤 방식으로 해결했는지 적어주세요
- 사업자 인경우, 정산정보가 입력된 경우 기존 정보를 가져와서 채우는 기능을 구현했습니다.
