### PR TITLE
[YP-777] feat : 서버시간조회 API 추가

### DIFF
--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/time/controller/ServerTimeController.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/time/controller/ServerTimeController.java
@@ -1,0 +1,27 @@
+package kr.co.yourplanet.online.business.time.controller;
+
+import java.time.LocalDateTime;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.yourplanet.core.enums.StatusCode;
+import kr.co.yourplanet.online.business.time.dto.ServerTimeResponse;
+import kr.co.yourplanet.online.common.ResponseForm;
+
+@Tag(name = "ServerTime", description = "서버 시간 API")
+@RestController
+public class ServerTimeController {
+
+    @Operation(summary = "서버 시간 조회")
+    @GetMapping(value = "/api/time")
+    public ResponseEntity<ResponseForm<ServerTimeResponse>> getServerTime() {
+        LocalDateTime now = LocalDateTime.now();
+
+        return ResponseEntity.ok(new ResponseForm<>(StatusCode.OK, new ServerTimeResponse(now)));
+    }
+
+}

--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/time/dto/ServerTimeResponse.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/time/dto/ServerTimeResponse.java
@@ -1,0 +1,21 @@
+package kr.co.yourplanet.online.business.time.dto;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record ServerTimeResponse(
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @NotNull
+    @Schema(
+        type = "string",
+        format = "date-time",
+        example = "2025-04-05 16:23:45",
+        description = "서버 현재 시간 (yyyy-MM-dd HH:mm:ss)"
+    )
+    LocalDateTime serverTime
+) {
+}


### PR DESCRIPTION
Jira: YP-777

## 💡 유형
- [X] 새로운 기능 추가

## 💁 해결하려는 문제를 적어주세요
- 나의 프로젝트 조회 화면에서 검토임박/발송지연 등과 같은 알림 노출시 기준이 되는 시간 정보가 필요합니다.
<img width="892" alt="image" src="https://github.com/user-attachments/assets/6f5b24bf-73ce-40af-99cc-79c91325684c" />
- 통일된 시간 계산을 위해 백엔드 서버 시간을 조회하여 계산합니다.

## 🤔 어떤 방식으로 해결했는지 적어주세요
- 백엔드 서버 시간 조회 API 개발

## 🙋 중점적으로 리뷰 했으면 하는 부분이 있다면 적어주세요
- 

## 🧑‍🏫 이해를 위해 필요한 자료가 있다면 첨부해주세요
- 
