### PR TITLE
[YP-527] fix: 멤버 회원가입, 정보 수정 입력 값 검증 방식 수정

### DIFF
--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/user/dto/request/BaseUpdateForm.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/user/dto/request/BaseUpdateForm.java
@@ -4,11 +4,8 @@ import java.time.LocalDate;
 
 import org.springframework.format.annotation.DateTimeFormat;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import kr.co.yourplanet.core.enums.BusinessType;
 import kr.co.yourplanet.core.validation.annotation.ValidEnum;
@@ -34,13 +31,4 @@ public class BaseUpdateForm {
 
     @Valid
     private BusinessForm businessForm;
-
-    @AssertTrue(message = "사업자 회원은 사업자 정보를 반드시 입력해야 합니다.")
-    @JsonIgnore
-    public boolean isBusinessValid() {
-        if (BusinessType.BUSINESS.equals(businessType)) {
-            return businessForm != null;
-        }
-        return true;
-    }
 }

--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/user/dto/request/MemberJoinForm.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/user/dto/request/MemberJoinForm.java
@@ -1,26 +1,16 @@
 package kr.co.yourplanet.online.business.user.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
-import kr.co.yourplanet.core.enums.MemberType;
 import lombok.Getter;
 
 @Getter
 public class MemberJoinForm {
 
     @Valid
-    @NotNull(message = "멤버 기본 정보 요청은 null일 수 없습니다.")
+    @NotNull(message = "멤버 기본 정보는 null일 수 없습니다.")
     private BaseJoinForm baseJoinForm;
 
     @Valid
     private CreatorJoinForm creatorJoinForm;
-
-    @AssertTrue(message = "선택한 멤버 유형에 해당하는 가입 정보를 입력해야 합니다.")
-    @JsonIgnore
-    private boolean isValidCreatorRequest() {
-        return !MemberType.CREATOR.equals(baseJoinForm.getMemberType()) || creatorJoinForm != null;
-    }
 }

--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/user/dto/request/MemberUpdateForm.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/user/dto/request/MemberUpdateForm.java
@@ -1,9 +1,6 @@
 package kr.co.yourplanet.online.business.user.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,13 +15,4 @@ public class MemberUpdateForm {
 
     @Valid
     private CreatorUpdateForm creatorUpdateForm;
-
-    @AssertTrue(message = "기본 정보의 사업자 여부와 정산 정보의 사업자 여부가 다릅니다.")
-    @JsonIgnore
-    private boolean isBusinessTypeMatches() {
-        if (creatorUpdateForm != null && creatorUpdateForm.getSettlementForm() != null) {
-            return baseUpdateForm.getBusinessType() == creatorUpdateForm.getSettlementForm().getBusinessType();
-        }
-        return true;
-    }
 }

--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/user/dto/request/SettlementForm.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/user/dto/request/SettlementForm.java
@@ -35,23 +35,4 @@ public class SettlementForm {
     @Schema(defaultValue = "123456-1234567")
     @Pattern(regexp = "^\\d{6}-\\d{7}$", message = "유효한 주민등록번호 형식이 아닙니다.")
     private String rrn;
-
-
-    @AssertTrue(message = "사업자 회원은 사업자 정산 정보를 반드시 입력해야 합니다.")
-    @JsonIgnore
-    public boolean isBusinessSettlement() {
-        if (BusinessType.BUSINESS.equals(businessType)) {
-            return bankAccountCopyFileId != null && businessLicenseFileId != null;
-        }
-        return true;
-    }
-
-    @AssertTrue(message = "개인 회원은 개인 정산 정보를 반드시 입력해야 합니다.")
-    @JsonIgnore
-    public boolean isIndividualSettlement() {
-        if (BusinessType.INDIVIDUAL.equals(businessType)) {
-            return rrn != null;
-        }
-        return true;
-    }
 }

--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/user/service/MemberJoinService.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/user/service/MemberJoinService.java
@@ -8,14 +8,13 @@ import kr.co.yourplanet.core.entity.member.MemberSalt;
 import kr.co.yourplanet.core.entity.member.MemberBasicInfo;
 import kr.co.yourplanet.core.enums.BusinessType;
 import kr.co.yourplanet.core.enums.MemberType;
-import kr.co.yourplanet.core.enums.StatusCode;
 import kr.co.yourplanet.online.business.user.dto.request.BaseJoinForm;
 import kr.co.yourplanet.online.business.user.dto.request.CreatorJoinForm;
 import kr.co.yourplanet.online.business.user.dto.request.MemberJoinForm;
 import kr.co.yourplanet.online.business.user.repository.MemberRepository;
 import kr.co.yourplanet.online.business.user.repository.MemberSaltRepository;
 import kr.co.yourplanet.online.common.encrypt.EncryptManager;
-import kr.co.yourplanet.online.common.exception.BusinessException;
+import kr.co.yourplanet.online.common.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
 
 @Transactional
@@ -49,11 +48,11 @@ public class MemberJoinService {
         memberValidationService.validatePasswordFormat(baseForm.getPassword());
 
         if (BusinessType.BUSINESS.equals(baseForm.getBusinessType()) && baseForm.getBusinessForm() == null) {
-            throw new BusinessException(StatusCode.BAD_REQUEST, "사업자 회원은 사업자 정보를 반드시 입력해야 합니다.", false);
+            throw new BadRequestException("사업자 회원은 사업자 정보를 반드시 입력해야 합니다.");
         }
 
         if (MemberType.CREATOR.equals(baseForm.getMemberType()) && joinForm.getCreatorJoinForm() == null) {
-            throw new BusinessException(StatusCode.BAD_REQUEST, "작가 가입을 위해 필요한 정보가 누락되었습니다.", false);
+            throw new BadRequestException("작가 가입을 위해 필요한 정보가 누락되었습니다.");
         }
     }
 


### PR DESCRIPTION
## 💡 유형
- [x] 버그 수정
- [x] 코드 리팩토링

## 💁 해결하려는 문제를 적어주세요
- 클라이언트에서 서버에 정해진 형식이 아닌 요청을 전송했을 때, 명확한 에러 메시지가 전송되지 않는 에러가 있었습니다.

## 🤔 어떤 방식으로 해결했는지 적어주세요
- Spring에서 잘못된 형식의 요청 본문을 객체로 직렬화 할 때 형식이 완전히 일치하지 않아도 에러를 발생시키지 않고, 존재하는 필드만 매핑하고 그 외에는 구성요소가 불완전한 request body 객체를 생성한다고 합니다.
- 따라서 본문 형식 에러가 아닌 validation 메서드가 먼저 호출되게 되는데, 불완전한 객체에서 이를 호출하지 못해 해당 에러가 발생하였습니다.
![image](https://github.com/user-attachments/assets/c837215d-4f60-4477-935e-6dea0964cbe8)
- 따라서 dto 내부에서 입력 값 validation을 하는 코드를 삭제하고, 검증 로직을 각 join / update service에 명시적으로 작성했습니다.

## 🧑‍🏫 이해를 위해 필요한 자료가 있다면 첨부해주세요
- 결과
  - 잘못된 형식의 본문으로 요청 시 입력 값 관련 에러 메시지를 전송하는 것으로 수정되었습니다.
![image](https://github.com/user-attachments/assets/a5299fe7-255b-470c-b861-52f67fdaff42)

