### PR TITLE
[YP-856] feat : 프로젝트 협상/수락/거절(취소) 시 알림톡 발송

### DIFF
--- a/yp-core/src/main/java/kr/co/yourplanet/core/alimtalk/dto/AlimTalkSendResponseForm.java
+++ b/yp-core/src/main/java/kr/co/yourplanet/core/alimtalk/dto/AlimTalkSendResponseForm.java
@@ -1,5 +1,8 @@
 package kr.co.yourplanet.core.alimtalk.dto;
 
+import lombok.Builder;
+
+@Builder
 public record AlimTalkSendResponseForm(
 
     String code,

--- a/yp-core/src/main/java/kr/co/yourplanet/core/enums/AlimTalkTemplateCode.java
+++ b/yp-core/src/main/java/kr/co/yourplanet/core/enums/AlimTalkTemplateCode.java
@@ -7,7 +7,13 @@ public enum AlimTalkTemplateCode {
 
     VERIFICATION_CODE("YP_ALIM_0001", "인증번호"),
     MEMBER_JOIN_CREATOR("YP_ALIM_0002", "회원가입 완료 작가"),
-    MEMBER_JOIN_SPONSOR("YP_ALIM_0003", "회원가입 완료 광고주");
+    MEMBER_JOIN_SPONSOR("YP_ALIM_0003", "회원가입 완료 광고주"),
+    PROJECT_NEGOTIATE_COMMON("YP_ALIM_0005", "신규 협상 접수 알림(공통)"),
+    PROJECT_ACCEPT_CREATOR("YP_ALIM_0006", "의뢰 수락 알림(작가)"),
+    PROJECT_ACCEPT_SPONSOR("YP_ALIM_0007", "의뢰 수락 알림(브랜드 파트너)"),
+    PROJECT_REJECT_SPONSOR("YP_ALIM_0014", "프로젝트 거절 알림(브랜드 파트너)"),
+    PROJECT_CANCEL_CREATOR("YP_ALIM_0015", "프로젝트 취소 알림(작가)");
+
 
     private final String code;
     private final String description;

--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/project/service/impl/ProjectServiceImpl.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/project/service/impl/ProjectServiceImpl.java
@@ -18,6 +18,7 @@ import kr.co.yourplanet.core.enums.FileType;
 import kr.co.yourplanet.core.enums.MemberType;
 import kr.co.yourplanet.core.enums.ProjectStatus;
 import kr.co.yourplanet.core.enums.StatusCode;
+import kr.co.yourplanet.online.business.alimtalk.util.BusinessAlimTalkSendUtil;
 import kr.co.yourplanet.online.business.file.service.FileQueryService;
 import kr.co.yourplanet.online.business.file.service.FileService;
 import kr.co.yourplanet.online.business.file.service.FileUrlService;
@@ -60,6 +61,8 @@ public class ProjectServiceImpl implements ProjectService {
     private final FileService fileService;
     private final FileQueryService fileQueryService;
     private final FileUrlService fileUrlService;
+
+    private final BusinessAlimTalkSendUtil businessAlimTalkSendUtil;
 
     @Override
     @Transactional
@@ -142,13 +145,23 @@ public class ProjectServiceImpl implements ProjectService {
         // 취소or거절 가능 상태인지 확인
         if (MemberType.CREATOR.equals(member.getMemberType())) {
             projectStatusAction = ProjectStatus.REJECTED;
-
         } else if (MemberType.SPONSOR.equals(member.getMemberType())) {
             projectStatusAction = ProjectStatus.CANCELED;
+        } else {
+            throw new BusinessException(StatusCode.BAD_REQUEST, "유효하지 않은 사용자 유형입니다.", false);
         }
+
         validateProjectStatusTransition(member, project, projectStatusAction);
 
+        // 프로젝트 취소/거절 처리
         project.invalidate(projectStatusAction, projectRejectForm.getReason());
+
+        // 알림톡 발송
+        if (MemberType.CREATOR.equals(member.getMemberType())) {
+            businessAlimTalkSendUtil.sendProjectRejectSponsor(project.getSponsor().getId(), project.getCreator().getId(), project.getId());
+        } else if (MemberType.SPONSOR.equals(member.getMemberType())) {
+            businessAlimTalkSendUtil.sendProjectCancelCreator(project.getCreator().getId());
+        }
 
     }
 
@@ -196,6 +209,15 @@ public class ProjectServiceImpl implements ProjectService {
             .build();
         projectHistoryRepository.save(projectHistory);
 
+        // 알림톡 발송
+        if (MemberType.CREATOR.equals(requestMember.getMemberType())) {
+            // 작가가 협상 요청한 경우 -> 광고주에게 알림톡 발송
+            businessAlimTalkSendUtil.sendProjectNegotiationCommon(project.getSponsor().getId(), project.getSponsor().getId(), project.getId());
+        } else if (MemberType.SPONSOR.equals(requestMember.getMemberType())) {
+            // 광고주가 협상 요청한 경우 -> 작가에게 알림톡 발송
+            businessAlimTalkSendUtil.sendProjectNegotiationCommon(project.getCreator().getId(), project.getSponsor().getId(), project.getId());
+        }
+
     }
 
     @Override
@@ -220,6 +242,9 @@ public class ProjectServiceImpl implements ProjectService {
 
         // 프로젝트 정산 정보 생성
         projectSettlementService.createForAcceptedProject(requestMemberId, project.getId());
+
+        // 알림톡 발송
+        businessAlimTalkSendUtil.sendProjectAcceptCommon(project.getCreator().getId(), project.getSponsor().getId(), project.getId());
     }
 
     @Override


### PR DESCRIPTION
Jira: YP-856

## 💡 유형
- [V] 새로운 기능 추가
- [V] 코드 리팩토링

## 💁 해결하려는 문제를 적어주세요
- 프로젝트 프로세스(협상, 수락, 거절[취소]) 알림톡 발송 로직 추가
- 기존 알림톡 발송 유틸 `BusinessAlimTalkSendUtil` 로직을 일부 수정 하였습니다.
  - 이제 신규 알림톡 발송 메소드 추가시 `BusinessAlimTalkSendUtil.send(AlimTalkTemplateCode alimTalkTemplateCode, Member targetMember, Map<String, Object> contextObjectMap)` 메소드만 호출하면 됩니다.

- 프로젝트 관련 알림톡 발송 메소드 개발시 파라미터로 Entity 객체를 사용하려 했으나, `LazyInitializationException` 이슈 발생하였습니다.
(@Async를 사용하는 알림톡발송 비동기 메소드에서는 메인 프로세스의 Transaction에 벗어나 있기 때문)
```
/**
     * [프로젝트] 협상 접수 알림톡 발송
     * [수신자] 협상 검토자(작가 or 광고주)
     */
    @Async
    public void sendProjectNegotiationCommon(Member targetMember, Member sponsor, Project project) {
        ...
    }
```

## 🤔 어떤 방식으로 해결했는지 적어주세요
* Entity가 아닌 Entity key 값을 인자로 전달받으며, @Async 메소드에서 엔티티 조회하여 사용
/**
     * [프로젝트] 협상 접수 알림톡 발송
     * [수신자] 협상 검토자(작가 or 광고주)
     */
    @Async
    public void sendProjectNegotiationCommon(Long targetMemberId, Long sponsorId, Long projectId) {
        ...
    }
```
    

## 🙋 중점적으로 리뷰 했으면 하는 부분이 있다면 적어주세요
- 

## 🧑‍🏫 이해를 위해 필요한 자료가 있다면 첨부해주세요
* 비동기 메소드에서 `LazyInitializationException`  
  <img width="982" alt="image" src="https://github.com/user-attachments/assets/018e70a4-d096-40f0-9e15-635e276033c1" />

