### PR TITLE
[YP-735] feat: 프로젝트 정산 상세 정보 조회 API 구현

### DIFF
--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/settlement/controller/SettlementController.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/settlement/controller/SettlementController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,6 +16,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.yourplanet.core.entity.settlement.SettlementPaymentStatus;
 import kr.co.yourplanet.core.entity.settlement.SettlementStatus;
 import kr.co.yourplanet.core.enums.StatusCode;
+import kr.co.yourplanet.online.business.settlement.dto.ProjectSettlementDetailInfo;
 import kr.co.yourplanet.online.business.settlement.dto.ProjectSettlementSummariesInfo;
 import kr.co.yourplanet.online.business.settlement.service.ProjectSettlementQueryService;
 import kr.co.yourplanet.online.common.ResponseForm;
@@ -44,11 +46,19 @@ public class SettlementController {
     @Operation(summary = "프로젝트 정산 정보 목록 조회")
     @GetMapping("/project")
     public ResponseEntity<ResponseForm<ProjectSettlementSummariesInfo>> getProjectSettlements(
-            @AuthenticationPrincipal JwtPrincipal jwtPrincipal,
             Pageable pageable
     ) {
         ProjectSettlementSummariesInfo response = projectSettlementQueryService.getSummariesInfo(pageable);
+        return new ResponseEntity<>(new ResponseForm<>(StatusCode.OK, response), HttpStatus.OK);
+    }
 
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "프로젝트 정산 상세 정보 조회")
+    @GetMapping("/project/{projectId}")
+    public ResponseEntity<ResponseForm<ProjectSettlementDetailInfo>> getProjectSettlementDetail(
+            @PathVariable Long projectId
+    ) {
+        ProjectSettlementDetailInfo response = projectSettlementQueryService.getDetailInfo(projectId);
         return new ResponseEntity<>(new ResponseForm<>(StatusCode.OK, response), HttpStatus.OK);
     }
 }

--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/settlement/dto/ProjectSettlementDetailInfo.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/settlement/dto/ProjectSettlementDetailInfo.java
@@ -1,0 +1,20 @@
+package kr.co.yourplanet.online.business.settlement.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record ProjectSettlementDetailInfo(
+        @Schema(description = "브랜드 파트너 정보")
+        SponsorInfo sponsorInfo,
+
+        @Schema(description = "프로젝트 정보")
+        ProjectBasicInfo projectBasicInfo,
+
+        @Schema(description = "프로젝트 상세 정보")
+        ProjectSpecInfo projectSpecInfo,
+
+        @Schema(description = "정산 정보")
+        SettlementInfo settlementInfo
+) {
+}

--- a/yp-online/src/main/java/kr/co/yourplanet/online/business/settlement/dto/ProjectSpecInfo.java
+++ b/yp-online/src/main/java/kr/co/yourplanet/online/business/settlement/dto/ProjectSpecInfo.java
@@ -5,7 +5,9 @@ import java.time.LocalDate;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
+@Builder
 public record ProjectSpecInfo(
 
         @Schema(description = "작업 기한")

--- a/yp-online/src/main/resources/db/migration/V1.16_modify_column_tel_unique.sql
+++ b/yp-online/src/main/resources/db/migration/V1.16_modify_column_tel_unique.sql
@@ -1,0 +1,3 @@
+-- 멤버의 전화번호에 unique 제약 추가
+ALTER TABLE member
+    ADD CONSTRAINT uq_member_tel UNIQUE (tel);

--- a/yp-online/src/test/java/kr/co/yourplanet/online/business/settlement/controller/SettlementControllerTest.java
+++ b/yp-online/src/test/java/kr/co/yourplanet/online/business/settlement/controller/SettlementControllerTest.java
@@ -50,4 +50,66 @@ class SettlementControllerTest extends IntegrationTest {
                     .andExpect(status().isOk());
         }
     }
+
+    @Nested
+    @DisplayName("프로젝트 정산 목록 조회 API")
+    class GetProjectSettlementSummaries {
+
+        private static final String PATH = "/settlement/project";
+
+        @DisplayName("[성공] 관리자는 프로젝트 정산 목록 조회에 성공한다.")
+        @Test
+        @WithMockJwtPrincipal(id = 0L, memberType = MemberType.ADMIN)
+        void success_admin() throws Exception {
+            mockMvc.perform(get(PATH)
+                            .header(HeaderConstant.ACCESS_TOKEN, TokenStub.getMockAccessToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .param("page", "0")
+                            .param("size", "10"))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @DisplayName("[실패] 관리자가 아니라면 프로젝트 정산 목록 조회에 실패한다.")
+        @Test
+        @WithMockJwtPrincipal(id = 1L, memberType = MemberType.CREATOR)
+        void fail_when_is_not_admin() throws Exception {
+            mockMvc.perform(get(PATH)
+                            .header(HeaderConstant.ACCESS_TOKEN, TokenStub.getMockAccessToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .param("page", "0")
+                            .param("size", "10"))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("프로젝트 정산 상세 조회 API")
+    class GetProjectSettlementDetail {
+
+        private static final String PATH = "/settlement/project/{projectId}";
+
+        @DisplayName("[성공] 관리자는 프로젝트 정산 상세 조회에 성공한다.")
+        @Test
+        @WithMockJwtPrincipal(id = 0L, memberType = MemberType.ADMIN)
+        void success_admin() throws Exception {
+            mockMvc.perform(get(PATH, 1)
+                            .header(HeaderConstant.ACCESS_TOKEN, TokenStub.getMockAccessToken())
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+
+        @DisplayName("[실패] 관리자가 아니라면 프로젝트 정산 목록 조회에 실패한다.")
+        @Test
+        @WithMockJwtPrincipal(id = 1L, memberType = MemberType.CREATOR)
+        void fail_when_is_not_admin() throws Exception {
+            mockMvc.perform(get(PATH, 1)
+                            .header(HeaderConstant.ACCESS_TOKEN, TokenStub.getMockAccessToken())
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
+        }
+    }
 }

--- a/yp-online/src/test/resources/db/setup.sql
+++ b/yp-online/src/test/resources/db/setup.sql
@@ -1,5 +1,26 @@
 -- MEMBER --
 
+-- ID: 0
+-- 관리자
+INSERT INTO member (id,
+                    email,
+                    name,
+                    tel,
+                    password,
+                    privacy_policy_agreed_time,
+                    terms_of_service_agreed_time)
+VALUES (0,
+        'admin@gmail.com',
+        '관리자',
+        '01012345678',
+        '2CJn2ppvaleyrs3bZk+dP1Pe2DfoO5eKD+1h1rnI/kQ=',
+        NOW(),
+        NOW());
+
+INSERT INTO member_salt (id, member_id, create_date, update_date, salt)
+VALUES (0, 0, '2025-02-24 13:07:45.755085', '2025-02-24 13:07:45.755085',
+        'ici1vf8rgNYbn5s0n9ik3cFM492EQUIwlxcveOV9//k=');
+
 -- ID: 1
 -- 작가: 사업자
 INSERT INTO member (id, email, password, name, gender_type, member_type, tel, birth_date,
@@ -282,7 +303,7 @@ VALUES (3, 4, 1, 'IN_PROGRESS', 3, 1, 2,
 INSERT INTO project_contract (id, project_id, accept_date_time, due_date, contract_amount,
                               provider_company_name, provider_registration_number, provider_address,
                               provider_representative_name, provider_written_date_time)
-VALUES (1, 3, '2025-03-18 12:00:00', '2025-03-20 18:00:00', 500000,
+VALUES (1, 3, '2025-03-18 12:00:00', '2025-03-20', 500000,
         '디자인 주식회사', '987-65-43210', '부산광역시 해운대구 센텀로 45',
         '이영희', '2025-03-18 10:00:00');
 
@@ -293,7 +314,7 @@ INSERT INTO project_contract (id, project_id, accept_date_time, due_date, contra
                               provider_company_name, provider_registration_number, provider_address,
                               provider_representative_name,
                               provider_written_date_time, client_written_date_time, complete_date_time)
-VALUES (2, 4, '2025-03-18 12:00:00', '2025-03-20 18:00:00', 750000,
+VALUES (2, 4, '2025-03-18 12:00:00', '2025-03-20', 750000,
         'ABC 기업', '123-45-67890', '서울특별시 강남구 테헤란로 123', '김철수',
         '디자인 주식회사', '987-65-43210', '부산광역시 해운대구 센텀로 45', '이영희',
         '2025-03-17 15:00:00', '2025-03-18 10:00:00', '2025-03-18 10:00:00');
@@ -348,7 +369,7 @@ VALUES (4,
         750000,
         675000,
         75000,
-'2025-03-18 10:00:00',
+        '2025-03-18 10:00:00',
         '2025-03-30 09:00:00',
         NULL,
         'PAYMENT_PENDING',


### PR DESCRIPTION
## 💡 유형
- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링

## 💁 해결하려는 문제를 적어주세요
- 프로젝트 정산 상세 정보를 조회하는 API를 구현했습니다.

## 🤔 어떤 방식으로 해결했는지 적어주세요
- 저번 PR에 포함되어 이미 합병된 부분이지만, spring security의 `@PreAuthorize("hasRole('ADMIN')")`를 사용하여 프로젝트 정산 API의 경우 `ADMIN` 멤버 타입이 아니라면 접근을 거부하는 로직을 추가했습니다.
``` java
public Collection<? extends GrantedAuthority> getAuthorities() {
    Set<GrantedAuthority> roles = new HashSet<>();
    roles.add(new SimpleGrantedAuthority(ROLE_PREFIX + this.memberType.toString()));
    return roles;
}
```
Authority를 생성할 때 멤버의 ROLE을 security가 인식할 수 있도록 prefix를 붙였습니다.

## 🙋 중점적으로 리뷰 했으면 하는 부분이 있다면 적어주세요
- 프로젝트 상세 정보 matching하는 코드에서 혹시 잘못된 값을 매칭하고 있다면 알려주시면 좋을 것 같습니다.
